### PR TITLE
feat!: route LLM translations through the genai-connector module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,22 @@
 This module adds AI-assisted translation capabilities to Jahia content (pages and content nodes), with support for:
 
 - DeepL translation
-- OpenAI translation
+- LLM translation through the platform [genai-connector](https://github.com/Jahia/genai-connector) module — with any provider the connector supports (Anthropic, OpenAI and OpenAI-compatible endpoints, Mistral, Azure OpenAI)
 - GraphQL translation suggestions and mutations
 - CSV-based glossaries managed inside Jahia
 
 ## Installation
 
-1. In Jahia, go to `Administration -> Server settings -> System components -> Modules`.
-2. Upload `ai-assisted-translations-X.X.X.jar`.
-3. Ensure the module is started.
-4. Activate the module on the websites where you want to use it.
+1. Deploy the [genai-connector](https://github.com/Jahia/genai-connector) module — it is declared in `Jahia-Depends`, so this module will not start without it.
+2. In Jahia, go to `Administration -> Server settings -> System components -> Modules`.
+3. Upload `ai-assisted-translations-X.X.X.jar`.
+4. Ensure the module is started.
+5. Activate the module on the websites where you want to use it.
 
 ## Runtime behavior
 
 - The module can expose one translation provider at a time through `TranslatorService`.
-- If both API keys are configured, OpenAI has priority over DeepL in current service activation logic.
+- A request goes to the highest-ranked translator that reports itself available: the LLM one (ranking `10`) when the genai-connector has a usable provider configured, DeepL (ranking `5`) otherwise.
 - From jContent, right click on `jnt:page` or `jnt:content` and use the translation menu:
   - translate to all site languages
   - translate to a specific target language
@@ -139,20 +140,36 @@ Main configuration file:
 
 - `src/main/resources/META-INF/configurations/org.jahia.community.translation.assisted.cfg`
 
+The **LLM provider, its API key and the default model** are *not* configured here: they live in
+the genai-connector module's own configuration (`org.jahia.modules.genai.cfg` — see its README).
+This module never sees a key.
+
 ### Main keys
 
 - `translation.deepl.api.key`
   - DeepL API key.
-- `translation.openai.api.key`
-  - OpenAI API key.
-- `translation.openai.model`
-  - OpenAI model used by translation requests.
-- `translation.openai.prompt`
-  - Base system prompt template.
+- `translation.llm.model`
+  - Optional model override, applied to translation requests only.
+  - Empty (the default) uses the model configured in the genai-connector.
+- `translation.llm.prompt`
+  - Base instructions template sent with every translation batch.
   - Supports `{{sourceLanguage}}` and `{{targetLanguage}}` placeholders.
 - `targetLanguages.<code>`
   - Optional mapping between Jahia language codes and provider-specific language codes.
   - Example: `targetLanguages.en=EN-US`, `targetLanguages.pt=PT-BR`.
+
+### Migration from 2.0.x
+
+The LLM path moved from an embedded OpenAI SDK to the genai-connector module:
+
+| Legacy key | Status |
+|---|---|
+| `translation.openai.api.key` | **Ignored** (logs a warning). Move the key to `org.jahia.modules.genai.cfg`; to keep using OpenAI, set that connector's provider to `openai`. |
+| `translation.openai.model` | Still read as a fallback for `translation.llm.model`, with a deprecation warning. |
+| `translation.openai.prompt` | Still read as a fallback for `translation.llm.prompt`, with a deprecation warning. |
+
+The secondary `org.jahia.community.translation.assisted.openai` configuration is obsolete and is
+deleted on startup, along with the API key it held.
 
 ### Glossary-related keys
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     </scm>
 
     <properties>
-        <jahia-depends>default,jcontent</jahia-depends>
+        <jahia-depends>default,jcontent,genai-connector</jahia-depends>
         <jahia.plugin.version>6.13</jahia.plugin.version>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <yarn.arguments>build:production</yarn.arguments>
@@ -38,14 +38,20 @@
             <artifactId>deepl-java</artifactId>
             <version>1.14.0</version>
         </dependency>
+        <!--
+          Platform GenAI connector: only its exported GenAiService API is compiled against; the
+          genai-connector bundle provides it at runtime (declared in Jahia-Depends). Transitives
+          are excluded so nothing from the connector's embedded stack reaches this bundle.
+        -->
         <dependency>
-            <groupId>com.openai</groupId>
-            <artifactId>openai-java</artifactId>
-            <version>4.26.0</version>
+            <groupId>org.jahia.modules</groupId>
+            <artifactId>genai-connector</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/main/java/org/jahia/community/translation/assisted/AssistedTranslationsConstants.java
+++ b/src/main/java/org/jahia/community/translation/assisted/AssistedTranslationsConstants.java
@@ -4,15 +4,21 @@ public class AssistedTranslationsConstants {
 
     public static final String SERVICE_CONFIG_FILE_NAME = "org.jahia.community.translation.assisted";
     public static final String SERVICE_CONFIG_FILE_NAME_DEEPL = SERVICE_CONFIG_FILE_NAME + ".deepl";
-    public static final String SERVICE_CONFIG_FILE_NAME_OPENAI = SERVICE_CONFIG_FILE_NAME + ".openai";
     public static final String SERVICE_CONFIG_FILE_FULLNAME = SERVICE_CONFIG_FILE_NAME + ".cfg";
     public static final String DEEPL_API_KEY = "translation.deepl.api.key";
-    public static final String OPENAI_API_KEY = "translation.openai.api.key";
-    public static final String TRANSLATION_OPENAI_PROMPT = "translation.openai.prompt";
-    public static final String TRANSLATION_OPENAI_MODEL = "translation.openai.model";
+    public static final String TRANSLATION_LLM_PROMPT = "translation.llm.prompt";
+    public static final String TRANSLATION_LLM_MODEL = "translation.llm.model";
     public static final String TRANSLATION_GLOSSARY_RELATIVE_PATH = "translation.glossary.relative.path";
     public static final String TRANSLATION_GLOSSARY_FILE_PATTERN = "translation.glossary.file.pattern";
     public static final String PROP_PREFIX_TARGET_LANGUAGES = "targetLanguages.";
+
+    // Legacy keys, kept for the migration to the genai-connector module (see jahia-private#5366).
+    // The API key is ignored — provider credentials now live in the connector's own configuration.
+    // The prompt and model keys are still read, as a fallback for the renamed provider-neutral ones.
+    public static final String LEGACY_OPENAI_CONFIG_FILE_NAME = SERVICE_CONFIG_FILE_NAME + ".openai";
+    public static final String LEGACY_OPENAI_API_KEY = "translation.openai.api.key";
+    public static final String LEGACY_TRANSLATION_OPENAI_PROMPT = "translation.openai.prompt";
+    public static final String LEGACY_TRANSLATION_OPENAI_MODEL = "translation.openai.model";
 
     public static final String MSG_NOTHING_TO_TRANSLATE = "Nothing to translate in %s";
     public static final String SLASH = "/";

--- a/src/main/java/org/jahia/community/translation/assisted/graphql/GqlJcrNodeMutationAssistedTranslation.java
+++ b/src/main/java/org/jahia/community/translation/assisted/graphql/GqlJcrNodeMutationAssistedTranslation.java
@@ -5,9 +5,9 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.community.translation.assisted.service.TranslatorService;
+import org.jahia.community.translation.assisted.service.TranslatorServiceResolver;
 import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNodeMutation;
-import org.jahia.osgi.BundleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,9 +33,9 @@ public class GqlJcrNodeMutationAssistedTranslation {
             logger.debug("Translating {} from {} to {}", nodeMutation.getNode().getPath(), sourceLocale, targetLocale);
         }
 
-        TranslatorService translatorService = BundleUtils.getOsgiService(TranslatorService.class, null);
+        TranslatorService translatorService = TranslatorServiceResolver.resolve().orElse(null);
         if (translatorService == null) {
-            logger.warn("No TranslatorService available – translation service is not configured");
+            logger.warn("No TranslatorService available – no translation provider is configured");
             throw new DataFetchingException("No translation service available. Please check the module configuration.");
         }
 
@@ -61,9 +61,9 @@ public class GqlJcrNodeMutationAssistedTranslation {
             logger.debug("Translating {}, property {}, from {} to {}", nodeMutation.getNode().getPath(), propertyName, sourceLocale, targetLocale);
         }
 
-        TranslatorService translatorService = BundleUtils.getOsgiService(TranslatorService.class, null);
+        TranslatorService translatorService = TranslatorServiceResolver.resolve().orElse(null);
         if (translatorService == null) {
-            logger.warn("No TranslatorService available – translation service is not configured");
+            logger.warn("No TranslatorService available – no translation provider is configured");
             throw new DataFetchingException("No translation service available. Please check the module configuration.");
         }
 

--- a/src/main/java/org/jahia/community/translation/assisted/graphql/GqlQueryTranslation.java
+++ b/src/main/java/org/jahia/community/translation/assisted/graphql/GqlQueryTranslation.java
@@ -5,9 +5,9 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.community.translation.assisted.service.TranslatorService;
+import org.jahia.community.translation.assisted.service.TranslatorServiceResolver;
 import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
-import org.jahia.osgi.BundleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,21 +33,17 @@ public class GqlQueryTranslation {
             @GraphQLName("targetLanguage") @GraphQLDescription("Language to translate to") String targetLocale
     ) {
         try {
-            TranslatorService translatorService = BundleUtils.getOsgiService(TranslatorService.class, null);
+            // The resolver already filters on availability, so anything it returns is usable.
+            TranslatorService translatorService = TranslatorServiceResolver.resolve().orElse(null);
             if (translatorService == null) {
-                logger.warn("No TranslatorService available – translation service is not configured");
+                logger.warn("No TranslatorService available – no translation provider is configured");
                 return Collections.emptyList();
             }
-            if (translatorService.isAvailable()) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug(String.format("Translating %s from %s to %s", node.getPath(), sourceLocale, targetLocale));
-                }
-                logger.info("Translating from {} to {} with provider {}", sourceLocale, targetLocale, translatorService.getProviderKey());
-                return translatorService.suggestTranslationForNode(node.getNode(), sourceLocale, targetLocale);
-            } else {
-                logger.warn("TranslatorService with provider key {} is not available", translatorService.getProviderKey());
-                return Collections.emptyList();
+            if (logger.isDebugEnabled()) {
+                logger.debug(String.format("Translating %s from %s to %s", node.getPath(), sourceLocale, targetLocale));
             }
+            logger.info("Translating from {} to {} with provider {}", sourceLocale, targetLocale, translatorService.getProviderKey());
+            return translatorService.suggestTranslationForNode(node.getNode(), sourceLocale, targetLocale);
         } catch (RepositoryException e) {
             throw new DataFetchingException("Error when suggesting translation", e);
         } catch (InterruptedException e) {

--- a/src/main/java/org/jahia/community/translation/assisted/service/TranslationServicesManagerImpl.java
+++ b/src/main/java/org/jahia/community/translation/assisted/service/TranslationServicesManagerImpl.java
@@ -12,6 +12,7 @@ import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.content.PublicationInfo;
 import org.jahia.services.content.nodetypes.ExtendedPropertyDefinition;
 import org.jahia.services.content.nodetypes.SelectorType;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Activate;
@@ -56,16 +57,15 @@ public class TranslationServicesManagerImpl implements TranslationServicesManage
             logger.warn("Missing configurations: {}", SERVICE_CONFIG_FILE_FULLNAME);
             return;
         }
-        final String openAIKey = properties.getOrDefault(OPENAI_API_KEY, "");
         final String deeplAIKey = properties.getOrDefault(DEEPL_API_KEY, "");
-        validateAtLeastOneKeyExist(deeplAIKey, openAIKey);
+        dropLegacyOpenAiConfiguration(properties);
+        validateDeepLKey(deeplAIKey);
         targetLanguages = transformTargetLanguagesPropertiesToMap(properties);
         String nodetypes = properties.getOrDefault("translation.nodetypes","jnt:page,jmix:mainResource,jmix:editorialContent,jnt:content,jnt:category");
         translatableNodeTypes = Arrays.asList(nodetypes.split(","));
         logger.info("Found translation nodetypes: {}", translatableNodeTypes.stream().map(StringUtils::trimToEmpty).collect(Collectors.joining(", ")));
         String treeNodetypes = properties.getOrDefault("translation.subtree.nodetypes","jnt:category");
         translatableNodeTypesForSubtree = Arrays.asList(treeNodetypes.split(","));
-        configureOpenAI(properties, openAIKey);
         configureDeepL(deeplAIKey);
     }
 
@@ -303,27 +303,9 @@ public class TranslationServicesManagerImpl implements TranslationServicesManage
 
     // Private configuration methods
 
-    private void configureOpenAI(Map<String, String> properties, String openAIKey) {
-        if (StringUtils.isNotEmpty(openAIKey)) {
-            try {
-                Configuration configuration = configurationAdmin.getConfiguration(SERVICE_CONFIG_FILE_NAME_OPENAI);
-                Map<String, String> configProperties = new HashMap<>();
-                configProperties.put(OPENAI_API_KEY, openAIKey);
-                if (properties.containsKey(TRANSLATION_OPENAI_PROMPT)) {
-                    configProperties.put(TRANSLATION_OPENAI_PROMPT, properties.get(TRANSLATION_OPENAI_PROMPT));
-                }
-                if (properties.containsKey(TRANSLATION_OPENAI_MODEL)) {
-                    configProperties.put(TRANSLATION_OPENAI_MODEL, properties.get(TRANSLATION_OPENAI_MODEL));
-                }
-                configuration.updateIfDifferent(new MapToDictionary(configProperties));
-            } catch (IOException e) {
-                throw new JahiaRuntimeException(e);
-            }
-        }
-    }
-
-    private void validateAtLeastOneKeyExist(String deeplAIKey, String openAIKey) {
-        // For non-existing key or empty key, we delete the configuration to make sure the service is not available. If both keys are empty, we log a warning.
+    private void validateDeepLKey(String deeplAIKey) {
+        // DeepL is gated by ConfigurationPolicy.REQUIRE on its own PID: deleting that configuration
+        // when no key is set is what keeps its component from registering.
         try {
             if (StringUtils.isEmpty(deeplAIKey)) {
                 Configuration configuration = configurationAdmin.getConfiguration(SERVICE_CONFIG_FILE_NAME_DEEPL);
@@ -335,25 +317,40 @@ public class TranslationServicesManagerImpl implements TranslationServicesManage
         } catch (IOException e) {
             logger.error("Error while deleting configuration for DeepL translator service: {}", e.getMessage());
         }
-        try {
-            if (StringUtils.isEmpty(openAIKey)) {
-                Configuration configuration = configurationAdmin.getConfiguration(SERVICE_CONFIG_FILE_NAME_OPENAI);
-                if (configuration != null) {
-                    configuration.delete();
-                }
-            }
-
-        } catch (IOException e) {
-            logger.error("Error while deleting configuration for OpenAI translator service: {}", e.getMessage());
-        }
-        if (StringUtils.isEmpty(deeplAIKey) && StringUtils.isEmpty(openAIKey)) {
-            logger.warn("No API key provided for DeepL and OpenAI translator services. No translator service will be available.");
-        } else if (!StringUtils.isEmpty(deeplAIKey) && !StringUtils.isEmpty(openAIKey)) {
-            logger.info("API keys provided for both DeepL and OpenAI translator services. Both services will be available.");
-        } else if (StringUtils.isNotEmpty(openAIKey)) {
-            logger.info("API key provided for OpenAI translator service. Only OpenAI translator service will be available.");
+        if (StringUtils.isEmpty(deeplAIKey)) {
+            logger.info("No DeepL API key provided. Translations will only be available if a provider is configured "
+                    + "in the genai-connector module.");
         } else {
-            logger.info("API key provided for DeepL translator service. Only DeepL translator service will be available.");
+            logger.info("API key provided for the DeepL translator service.");
+        }
+    }
+
+    /**
+     * Handles configurations written before the LLM path moved to the genai-connector module
+     * (jahia-private#5366): the OpenAI API key is no longer used here, and the secondary
+     * configuration it used to be pushed into no longer backs any component.
+     */
+    private void dropLegacyOpenAiConfiguration(Map<String, String> properties) {
+        if (StringUtils.isNotEmpty(properties.get(LEGACY_OPENAI_API_KEY))) {
+            logger.warn("The key {} found in {} is IGNORED since the migration to the genai-connector module: "
+                            + "configure the provider, its API key and its model in org.jahia.modules.genai.cfg instead.",
+                    LEGACY_OPENAI_API_KEY, SERVICE_CONFIG_FILE_FULLNAME);
+        }
+        try {
+            // listConfigurations, not getConfiguration: the latter would create the very
+            // configuration we are trying to get rid of when it is already gone.
+            Configuration[] configurations = configurationAdmin.listConfigurations(
+                    "(service.pid=" + LEGACY_OPENAI_CONFIG_FILE_NAME + ")");
+            if (configurations == null) {
+                return;
+            }
+            for (Configuration configuration : configurations) {
+                configuration.delete();
+            }
+            logger.info("Deleted the obsolete {} configuration left over by an earlier version, "
+                    + "along with the API key it held.", LEGACY_OPENAI_CONFIG_FILE_NAME);
+        } catch (IOException | InvalidSyntaxException e) {
+            logger.error("Error while deleting the obsolete configuration {}: {}", LEGACY_OPENAI_CONFIG_FILE_NAME, e.getMessage());
         }
     }
 

--- a/src/main/java/org/jahia/community/translation/assisted/service/TranslatorServiceResolver.java
+++ b/src/main/java/org/jahia/community/translation/assisted/service/TranslatorServiceResolver.java
@@ -1,0 +1,79 @@
+package org.jahia.community.translation.assisted.service;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Picks the {@link TranslatorService} that should serve a translation request: the
+ * highest-ranked one that is actually {@link TranslatorService#isAvailable() available}.
+ *
+ * <p>Service ranking alone is not enough. Before the migration to the genai-connector module,
+ * the LLM translator was gated by {@code ConfigurationPolicy.REQUIRE} on a configuration the
+ * manager deleted whenever no API key was set, so an unusable translator simply was not
+ * registered and a plain highest-ranking lookup landed on DeepL. The provider key now lives in
+ * the connector's own configuration, which this module gets no notification about — so the LLM
+ * translator stays registered even while the connector is unconfigured, and availability has to
+ * be checked at lookup time instead.</p>
+ */
+public final class TranslatorServiceResolver {
+
+    private static final Logger logger = LoggerFactory.getLogger(TranslatorServiceResolver.class);
+
+    private TranslatorServiceResolver() {
+    }
+
+    /**
+     * @return the highest-ranked available translator, or empty when none is configured
+     */
+    public static Optional<TranslatorService> resolve() {
+        Bundle bundle = FrameworkUtil.getBundle(TranslatorServiceResolver.class);
+        BundleContext bundleContext = bundle == null ? null : bundle.getBundleContext();
+        if (bundleContext == null) {
+            logger.warn("No bundle context available to look up a TranslatorService");
+            return Optional.empty();
+        }
+
+        final Collection<ServiceReference<TranslatorService>> references;
+        try {
+            references = bundleContext.getServiceReferences(TranslatorService.class, null);
+        } catch (InvalidSyntaxException e) {
+            // Unreachable: the filter is null.
+            logger.error("Unable to look up the TranslatorService implementations", e);
+            return Optional.empty();
+        }
+
+        // ServiceReference orders ascending by ranking, so reverse it to try the preferred one first.
+        List<ServiceReference<TranslatorService>> ranked = new ArrayList<>(references);
+        ranked.sort(Comparator.reverseOrder());
+
+        for (ServiceReference<TranslatorService> reference : ranked) {
+            TranslatorService translatorService = bundleContext.getService(reference);
+            if (translatorService == null) {
+                continue;
+            }
+            boolean available = translatorService.isAvailable();
+            // Both implementations are immediate DS components of this bundle: their lifecycle is
+            // owned by SCR, not by our usage count, so releasing the reference here is safe and
+            // keeps repeated lookups from inflating it.
+            bundleContext.ungetService(reference);
+            if (available) {
+                return Optional.of(translatorService);
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("Skipping translator {}: not available", translatorService.getProviderKey());
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/jahia/community/translation/assisted/service/impl/deepl/DeepLTranslatorServiceImpl.java
+++ b/src/main/java/org/jahia/community/translation/assisted/service/impl/deepl/DeepLTranslatorServiceImpl.java
@@ -97,7 +97,10 @@ public class DeepLTranslatorServiceImpl implements TranslatorService {
         }
         logger.info("Activating DeeplTranslator Service");
         final String authKey = properties.get(DEEPL_API_KEY);
-        if (authKey == null || properties.get(OPENAI_API_KEY) != null) {
+        // Availability used to also be revoked when an OpenAI key was present, to give the LLM path
+        // precedence. Precedence is now decided by service ranking plus the availability check in
+        // TranslatorServiceResolver, so DeepL only depends on its own key.
+        if (authKey == null) {
             available = false;
             return;
         }

--- a/src/main/java/org/jahia/community/translation/assisted/service/impl/llm/LlmTranslatorService.java
+++ b/src/main/java/org/jahia/community/translation/assisted/service/impl/llm/LlmTranslatorService.java
@@ -74,8 +74,9 @@ public class LlmTranslatorService implements TranslatorService {
      */
     private static final String DEFAULT_PROMPT_PATTERN = "You are a translation engine. Return only strict JSON object key->translated text. Preserve HTML tags/entities exactly. Preserve the JSON structure as received, translate only the values and keep the keys exactly as they are. The source language is {{sourceLanguage}} and the target language is {{targetLanguage}}. Those languages are expressed as ISO code with or without regional variations, if the variation is specified please ensure the translation match the regional specification. For example, if the target language is PT-BR, please ensure that the translation is in Brazilian Portuguese and not European Portuguese.";
 
-    private String promptPattern;
-    private String model;
+    // Reassigned by @Modified on every configuration change, read by request threads.
+    private volatile String promptPattern;
+    private volatile String model;
 
     @Reference
     private GenAiService genAiService;

--- a/src/main/java/org/jahia/community/translation/assisted/service/impl/llm/LlmTranslatorService.java
+++ b/src/main/java/org/jahia/community/translation/assisted/service/impl/llm/LlmTranslatorService.java
@@ -1,12 +1,5 @@
-package org.jahia.community.translation.assisted.service.impl.openai;
+package org.jahia.community.translation.assisted.service.impl.llm;
 
-import com.openai.client.OpenAIClient;
-import com.openai.client.okhttp.OpenAIOkHttpClient;
-import com.openai.models.ChatModel;
-import com.openai.models.ResponseFormatJsonObject;
-import com.openai.models.responses.Response;
-import com.openai.models.responses.ResponseCreateParams;
-import com.openai.models.responses.ResponseTextConfig;
 import org.apache.commons.lang3.StringUtils;
 import org.jahia.api.Constants;
 import org.jahia.community.translation.assisted.graphql.TranslatedField;
@@ -15,17 +8,22 @@ import org.jahia.community.translation.assisted.service.TranslationServicesManag
 import org.jahia.community.translation.assisted.service.TranslatorService;
 import org.jahia.community.translation.assisted.service.glossary.GlossaryService;
 import org.jahia.community.translation.assisted.service.glossary.ResolvedGlossary;
-import org.jahia.community.translation.assisted.service.impl.TranslationData;
 import org.jahia.community.translation.assisted.service.impl.AssistedTranslationResponseImpl;
+import org.jahia.community.translation.assisted.service.impl.TranslationData;
+import org.jahia.modules.genai.api.CompletionRequest;
+import org.jahia.modules.genai.api.CompletionResult;
+import org.jahia.modules.genai.api.GenAiInfo;
+import org.jahia.modules.genai.api.GenAiService;
+import org.jahia.modules.genai.api.ResponseFormat;
+import org.jahia.modules.genai.api.StopReason;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.utils.LanguageCodeConverters;
-import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,25 +36,49 @@ import java.util.stream.Collectors;
 
 import static org.jahia.community.translation.assisted.AssistedTranslationsConstants.*;
 
-
+/**
+ * LLM-backed {@link TranslatorService}, calling the platform
+ * <a href="https://github.com/Jahia/genai-connector">genai-connector</a> module through its
+ * exported {@link GenAiService} facade.
+ *
+ * <p>This module owns the <em>prompt</em> (instructions template + glossary injection), the
+ * batching and the JCR write-back; the connector owns the provider, the credentials and the
+ * transport. Any provider the connector supports — Anthropic, OpenAI and OpenAI-compatible
+ * endpoints, Mistral, Azure OpenAI — therefore works here, where this class used to speak the
+ * OpenAI Responses API through an embedded SDK (see jahia-private#5366).</p>
+ *
+ * <p>The component registers with {@code service.ranking=10.0}, above DeepL's {@code 5.0}, but
+ * ranking alone does not decide: consumers resolve translators through
+ * {@link org.jahia.community.translation.assisted.service.TranslatorServiceResolver}, which
+ * skips any translator whose {@link #isAvailable()} is {@code false}. So when the connector is
+ * installed but not yet configured with a provider, translation falls back to DeepL.</p>
+ */
 @Component(service = TranslatorService.class,
-        property = {"service.translation.provider=openai", "service.ranking=10.0"},
-        configurationPid = SERVICE_CONFIG_FILE_NAME_OPENAI,
-        immediate = true,
-        configurationPolicy = ConfigurationPolicy.REQUIRE)
-public class OpenAITranslatorService implements TranslatorService {
-    private static final Logger logger = LoggerFactory.getLogger(OpenAITranslatorService.class);
+        property = {"service.translation.provider=genai", "service.ranking=10.0"},
+        configurationPid = SERVICE_CONFIG_FILE_NAME,
+        immediate = true)
+public class LlmTranslatorService implements TranslatorService {
+    private static final Logger logger = LoggerFactory.getLogger(LlmTranslatorService.class);
+    private static final String PROVIDER_KEY = "genai";
     private static final int TRANSLATION_BATCH_SIZE = 200;
     private static final int MAX_GLOSSARY_TERMS_IN_PROMPT = 200;
     private static final String JSON_RESPONSE_INSTRUCTION = "Return only a valid JSON object with exactly the same keys as the input and translated string values. Do not add markdown or explanations.";
+    private static final String JSON_REPAIR_INSTRUCTION = "Your previous answer was not a valid JSON object. Answer again with a single valid JSON object and nothing else: no markdown code fences, no preamble, no trailing text.";
     private static final String JSON_INPUT_PREFIX = "json payload to translate:\n";
-    private static final ResponseTextConfig JSON_OBJECT_TEXT_CONFIG = ResponseTextConfig.builder()
-            .format(ResponseFormatJsonObject.builder().build())
-            .build();
-    private OpenAIClient openAIClient;
+
+    /**
+     * Used when neither {@code translation.llm.prompt} nor the legacy
+     * {@code translation.openai.prompt} is configured. It matches the template shipped in
+     * {@code org.jahia.community.translation.assisted.cfg}, so the service stays usable with a
+     * configuration that only carries provider-independent keys.
+     */
+    private static final String DEFAULT_PROMPT_PATTERN = "You are a translation engine. Return only strict JSON object key->translated text. Preserve HTML tags/entities exactly. Preserve the JSON structure as received, translate only the values and keep the keys exactly as they are. The source language is {{sourceLanguage}} and the target language is {{targetLanguage}}. Those languages are expressed as ISO code with or without regional variations, if the variation is specified please ensure the translation match the regional specification. For example, if the target language is PT-BR, please ensure that the translation is in Brazilian Portuguese and not European Portuguese.";
+
     private String promptPattern;
-    private ChatModel chatModel;
-    private boolean available;
+    private String model;
+
+    @Reference
+    private GenAiService genAiService;
 
     @Reference
     private TranslationServicesManager translationServicesManager;
@@ -72,52 +94,59 @@ public class OpenAITranslatorService implements TranslatorService {
         return JSON_INPUT_PREFIX + safeInput;
     }
 
-    private static Optional<String> extractOutputText(Response response) {
-        StringBuilder outputText = new StringBuilder();
-        response.output().stream()
-                .filter(com.openai.models.responses.ResponseOutputItem::isMessage)
-                .map(com.openai.models.responses.ResponseOutputItem::asMessage)
-                .flatMap(message -> message.content().stream())
-                .filter(com.openai.models.responses.ResponseOutputMessage.Content::isOutputText)
-                .map(content -> content.asOutputText().text())
-                .forEach(outputText::append);
-        if (outputText.length() == 0) {
-            return Optional.empty();
-        }
-        return Optional.of(outputText.toString());
-    }
-
     @Override
     public String getProviderKey() {
-        return "openai";
+        // Report the provider actually serving the calls, so logs name Anthropic/OpenAI/… rather
+        // than this module's generic key.
+        return genAiService.info().map(GenAiInfo::provider).orElse(PROVIDER_KEY);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Delegates to the connector: {@code true} only when a provider is configured there with
+     * a usable key. This is what makes the DeepL fallback work — the component itself is always
+     * registered once the connector bundle is present.</p>
+     */
     @Override
     public boolean isAvailable() {
-        return available;
+        return genAiService.isAvailable();
     }
 
     @Activate
+    @Modified
     public void activate(Map<String, String> properties) {
+        Map<String, String> safeProperties = properties == null ? Collections.emptyMap() : properties;
         if (properties == null) {
-            logger.warn("Missing configurations: {}", SERVICE_CONFIG_FILE_FULLNAME);
-            return;
+            logger.warn("Missing configurations: {} — falling back to the built-in prompt", SERVICE_CONFIG_FILE_FULLNAME);
         }
-        logger.info("Activating OpenAI Translator Service");
-        final String authKey = properties.get(OPENAI_API_KEY);
-        if (authKey == null) {
-            available = false;
-            return;
+        logger.info("Activating the LLM Translator Service (through the genai-connector module)");
+
+        String pattern = firstNonBlank(safeProperties, TRANSLATION_LLM_PROMPT, LEGACY_TRANSLATION_OPENAI_PROMPT);
+        if (pattern == null) {
+            pattern = DEFAULT_PROMPT_PATTERN;
+        } else if (!safeProperties.containsKey(TRANSLATION_LLM_PROMPT)) {
+            logger.warn("Configuration key {} is deprecated, rename it to {} in {}",
+                    LEGACY_TRANSLATION_OPENAI_PROMPT, TRANSLATION_LLM_PROMPT, SERVICE_CONFIG_FILE_FULLNAME);
         }
-        openAIClient = OpenAIOkHttpClient.builder().apiKey(authKey).build();
-        if (properties.containsKey(TRANSLATION_OPENAI_PROMPT)) {
-            String pattern = properties.get(TRANSLATION_OPENAI_PROMPT);
-            promptPattern = pattern.replace("{{sourceLanguage}}", "{0}").replace("{{targetLanguage}}", "{1}");
+        promptPattern = pattern.replace("{{sourceLanguage}}", "{0}").replace("{{targetLanguage}}", "{1}");
+
+        model = firstNonBlank(safeProperties, TRANSLATION_LLM_MODEL, LEGACY_TRANSLATION_OPENAI_MODEL);
+        if (model != null && !safeProperties.containsKey(TRANSLATION_LLM_MODEL)) {
+            logger.warn("Configuration key {} is deprecated, rename it to {} in {}",
+                    LEGACY_TRANSLATION_OPENAI_MODEL, TRANSLATION_LLM_MODEL, SERVICE_CONFIG_FILE_FULLNAME);
         }
-        if (properties.containsKey(TRANSLATION_OPENAI_MODEL)) {
-            chatModel = ChatModel.of(properties.get(TRANSLATION_OPENAI_MODEL));
+        logger.info("LLM translations configured with model {}", model == null ? "<genai-connector default>" : model);
+    }
+
+    private static String firstNonBlank(Map<String, String> properties, String... keys) {
+        for (String key : keys) {
+            String value = StringUtils.trimToNull(properties.get(key));
+            if (value != null) {
+                return value;
+            }
         }
-        available = true;
+        return null;
     }
 
     @Override
@@ -153,7 +182,7 @@ public class OpenAITranslatorService implements TranslatorService {
 
     @Override
     public AssistedTranslationResponse translateProperty(JCRNodeWrapper node, String propertyName, String sourceLanguage, String targetLanguage) throws RepositoryException, InterruptedException {
-        throw new UnsupportedOperationException("translateProperty is not supported in OpenAITranslatorService, please use translateNode instead");
+        throw new UnsupportedOperationException("translateProperty is not supported in LlmTranslatorService, please use translateNode instead");
     }
 
     @Override
@@ -164,13 +193,13 @@ public class OpenAITranslatorService implements TranslatorService {
         final TranslationData data = new TranslationData();
 
         translationServicesManager.buildDataToTranslate(localizedNode, data, true, false);
-        // Build JSON to send to OpenAI, using data.getTexts() which is a map of key->text to translate, where key is the JCR path to the property (e.g. /a/title) and value is the text to translate (e.g. "Hello <b>world</b>")
+        // Build the JSON to translate from data.getTexts(), a map of key->text where key is the JCR path
+        // to the property (e.g. /a/title) and value is the text to translate (e.g. "Hello <b>world</b>")
         ResolvedGlossary resolvedGlossary = glossaryService.resolve(localizedNode, sourceLanguage, targetLanguage);
         return getTranslatedFieldList(sourceLanguage, targetLanguage, data, false, resolvedGlossary.getTerms());
     }
 
-    private @NotNull List<TranslatedField> getTranslatedFieldList(String sourceLanguage, String targetLanguage, TranslationData data, boolean subtree, Map<String, String> glossaryTerms) {
-        // Use Responses API for translations.
+    private List<TranslatedField> getTranslatedFieldList(String sourceLanguage, String targetLanguage, TranslationData data, boolean subtree, Map<String, String> glossaryTerms) {
         String sourceLanguageMapped = translationServicesManager.getTargetLanguages().getOrDefault(sourceLanguage, sourceLanguage);
         String targetLanguageMapped = translationServicesManager.getTargetLanguages().getOrDefault(targetLanguage, targetLanguage);
         String baseSystemPrompt = MessageFormat.format(promptPattern, sourceLanguageMapped, targetLanguageMapped)
@@ -180,8 +209,9 @@ public class OpenAITranslatorService implements TranslatorService {
             return List.of();
         }
 
-        // Keep one conversation across batches with previous_response_id without replaying full history.
-        String previousResponseId = null;
+        // Every batch is self-contained: the OpenAI-only `previous_response_id` chaining was dropped
+        // with the SDK (jahia-private#5366). The full system prompt is re-sent per batch, which the
+        // former chaining also did — it only saved re-sending the previous *payloads*.
         Map<String, String> translatedValues = new HashMap<>();
 
         for (int startIdx = 0; startIdx < textEntries.size(); startIdx += TRANSLATION_BATCH_SIZE) {
@@ -203,26 +233,23 @@ public class OpenAITranslatorService implements TranslatorService {
             // tags come back as "<\/p>". Undo the over-escaping so the model sees clean HTML.
             String requestJson = new JSONObject(textsToTranslate).toString().replace("<\\/", "</");
             if (logger.isDebugEnabled()) {
-                logger.debug("Calling OpenAI API with requested translation batch [{}, {})", startIdx, endIdx);
+                logger.debug("Calling the genai-connector with requested translation batch [{}, {})", startIdx, endIdx);
             }
 
             String systemPrompt = baseSystemPrompt + buildGlossaryInstruction(glossaryTerms, textsToTranslate.values());
-            Response response = createTranslationResponse(requestJson, previousResponseId, systemPrompt);
-            previousResponseId = response.id();
-            Optional<JSONObject> responseJson = extractOutputText(response).flatMap(this::parseJsonObject);
+            Optional<JSONObject> responseJson = complete(systemPrompt, requestJson).flatMap(this::parseJsonObject);
 
             if (responseJson.isEmpty()) {
                 if (logger.isWarnEnabled()) {
-                    logger.warn("OpenAI response {} for batch [{}, {}) was not valid JSON, retrying once", response.id(), startIdx, endIdx);
+                    logger.warn("The response for batch [{}, {}) was not valid JSON, retrying once", startIdx, endIdx);
                 }
-                String repairPrompt = "Your previous answer was not valid JSON. " + JSON_RESPONSE_INSTRUCTION + " Input payload: " + requestJson;
-                Response retryResponse = createTranslationResponse(repairPrompt, previousResponseId, null);
-                previousResponseId = retryResponse.id();
-                responseJson = extractOutputText(retryResponse).flatMap(this::parseJsonObject);
+                // The repair call cannot refer to "the previous answer" the way the chained Responses API
+                // did, so it re-sends the same payload with a hardened instruction instead.
+                responseJson = complete(systemPrompt + "\n" + JSON_REPAIR_INSTRUCTION, requestJson).flatMap(this::parseJsonObject);
             }
 
             if (responseJson.isEmpty()) {
-                logger.error("OpenAI did not return valid JSON for translation batch [{}, {})", startIdx, endIdx);
+                logger.error("The model did not return valid JSON for translation batch [{}, {})", startIdx, endIdx);
                 return List.of();
             }
 
@@ -232,8 +259,35 @@ public class OpenAITranslatorService implements TranslatorService {
         return translationServicesManager.getTranslatedFieldList(data, subtree, translatedValues);
     }
 
+    /**
+     * Runs one completion through the connector in native JSON-object mode.
+     *
+     * @return the generated text, or empty when the model produced nothing usable
+     */
+    private Optional<String> complete(String instructions, String input) {
+        CompletionRequest.Builder request = CompletionRequest.builder()
+                .instructions(instructions)
+                // Native JSON mode of some providers (OpenAI's in particular) requires the word "json"
+                // to appear in the prompt; the payload alone does not always contain it.
+                .input(ensureJsonKeywordInInput(input))
+                .responseFormat(ResponseFormat.JSON);
+        if (model != null) {
+            request.model(model);
+        }
+        CompletionResult result = genAiService.complete(request.build());
+        if (result.stopReason() == StopReason.MAX_TOKENS) {
+            logger.warn("The model stopped on its output-token limit: the JSON is truncated and will not parse. "
+                    + "Raise the max output tokens in the genai-connector configuration, or lower the translation batch size.");
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("Translation batch served by {}/{} ({} input tokens, {} output tokens)",
+                    result.provider(), result.model(), result.usage().inputTokens(), result.usage().outputTokens());
+        }
+        return Optional.of(result.text()).filter(StringUtils::isNotBlank);
+    }
+
     private static void processJsonResponse(Optional<JSONObject> responseJson, Map<String, String> textsToTranslate, Map<String, String> translatedValues) {
-        if(responseJson.isPresent()) {
+        if (responseJson.isPresent()) {
             Map<String, Object> responseJsonMap = responseJson.get().toMap();
             textsToTranslate.keySet().forEach(key -> {
                 if (responseJsonMap.containsKey(key) && responseJsonMap.get(key) != null) {
@@ -260,21 +314,6 @@ public class OpenAITranslatorService implements TranslatorService {
                 translatedValues.put(key, glossaryMatch);
             }
         });
-    }
-
-    private Response createTranslationResponse(String input, String previousResponseId, String instructions) {
-        ResponseCreateParams.Builder paramsBuilder = ResponseCreateParams
-                .builder()
-                .model(chatModel)
-                .text(JSON_OBJECT_TEXT_CONFIG)
-                .input(ensureJsonKeywordInInput(input));
-        if (instructions != null) {
-            paramsBuilder.instructions(instructions);
-        }
-        if (previousResponseId != null) {
-            paramsBuilder.previousResponseId(previousResponseId);
-        }
-        return openAIClient.responses().create(paramsBuilder.build());
     }
 
     private String buildGlossaryInstruction(Map<String, String> glossaryTerms, Collection<String> batchTexts) {
@@ -335,7 +374,7 @@ public class OpenAITranslatorService implements TranslatorService {
             return Optional.of(new JSONObject(content));
         } catch (Exception e) {
             if (logger.isDebugEnabled()) {
-                logger.debug("Unable to parse OpenAI output as JSON: {}", content, e);
+                logger.debug("Unable to parse the model output as JSON: {}", content, e);
             }
             return Optional.empty();
         }

--- a/src/main/resources/META-INF/configurations/org.jahia.community.translation.assisted.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.community.translation.assisted.cfg
@@ -2,12 +2,23 @@
 targetLanguages.en=EN-US
 targetLanguages.pt=PT-BR
 translation.deepl.api.key=
-translation.openai.api.key=
-# OpenAI model to use for translation. See https://platform.openai.com/docs/models for more details.
-#translation.openai.model=gpt-5.1
-translation.openai.model=gpt-4.1-mini
-# Prompt to use for OpenAI translation. {{sourceLanguage}} and {{targetLanguage}} will be replaced with the actual language codes. You can use this prompt to instruct the model to preserve HTML tags/entities, or to return the translation in a specific format (e.g. JSON).
-translation.openai.prompt="You are a translation engine. Return only strict JSON object key->translated text.Preserve HTML tags/entities exactly. Preserve the JSON structure as received, translate only the values and keep the keys exactly as they are. The source language is {{sourceLanguage}} and the target language is {{targetLanguage}}. Those languages are expressed as ISO code with or without regional variations, if the variation is specified please ensure the translation match the regional specification. For example, if the target language is PT-BR, please ensure that the translation is in Brazilian Portuguese and not European Portuguese."
+
+# --- LLM translations (through the genai-connector module) ---
+# The provider, its API key and the default model are configured centrally in the genai-connector
+# module (org.jahia.modules.genai.cfg) - this module never sees a key. LLM translations are used
+# whenever that connector reports an available provider, and fall back to DeepL otherwise.
+#
+# Optional model override, applied to translation requests only. Leave empty to use the model
+# configured in the connector. Any model of the configured provider is valid here.
+translation.llm.model=
+# Instructions template sent with every translation batch. {{sourceLanguage}} and {{targetLanguage}}
+# are replaced with the actual language codes. Use it to instruct the model to preserve HTML
+# tags/entities, or to enforce regional variants.
+translation.llm.prompt=You are a translation engine. Return only strict JSON object key->translated text. Preserve HTML tags/entities exactly. Preserve the JSON structure as received, translate only the values and keep the keys exactly as they are. The source language is {{sourceLanguage}} and the target language is {{targetLanguage}}. Those languages are expressed as ISO code with or without regional variations, if the variation is specified please ensure the translation match the regional specification. For example, if the target language is PT-BR, please ensure that the translation is in Brazilian Portuguese and not European Portuguese.
+
+# Migration note (from 2.0.x): translation.openai.api.key is IGNORED - move the key to the
+# genai-connector configuration. translation.openai.prompt and translation.openai.model are still
+# read as a fallback for the two keys above, with a deprecation warning.
 
 # Glossary CSV discovery (files are managed in Jahia and loaded from this site-relative folder).
 translation.glossary.relative.path=/files/glossaries


### PR DESCRIPTION
Implements Jahia/jahia-private#5366 (EPIC Jahia/jahia-private#4327, Phase 3).

The LLM translation path moves off the embedded `com.openai:openai-java` SDK and onto the platform [genai-connector](https://github.com/Jahia/genai-connector)'s exported `GenAiService`. Translations can now run on any provider the connector supports — Anthropic, OpenAI and OpenAI-compatible endpoints, Mistral, Azure OpenAI — instead of OpenAI only.

**DeepL is untouched as a translation engine.** It is machine translation with server-side glossaries and native HTML tag handling, not an LLM, and keeps `deepl-java`.

## What moved

`OpenAITranslatorService` → `LlmTranslatorService`. This module keeps everything that is about *translation*; the connector takes everything that is about *talking to a provider*:

| Stays here | Moves to the connector |
|---|---|
| Instructions template + glossary injection | Provider selection |
| 200-field batching | API key |
| JCR write-back, multivalued field handling | Model default, timeouts, retries |
| `TranslatorService` interface and its ranking | HTTP transport |

Native JSON-object mode is requested with `ResponseFormat.JSON`, and both OpenAI-specific workarounds called out in the issue are preserved: the `<\/` unescaping before the payload is sent, and the `"json"` keyword requirement in JSON mode.

## Behaviour changes worth reviewing

**`previousResponseId` chaining is dropped** (OpenAI-specific, as the issue anticipated). Each batch was already re-sending the full system prompt, so the only new cost is re-sending each batch payload once — no behavioural difference in the output.

**The JSON repair retry was restructured.** It used to say *"your previous answer was not valid JSON"*, which only meant something because the retry was chained to the failed response. Without chaining that sentence refers to nothing, so the retry now re-sends the same payload with a hardened instruction instead. Kept as a safety net on top of native JSON mode, as the issue asked.

**Translator selection now picks the highest-ranked *available* service**, via a new `TranslatorServiceResolver`, where the GraphQL layer previously took the highest-ranked one outright (`BundleUtils.getOsgiService`). This is required for the issue's provider-fallback scenario. Until now "available" and "registered" were the same thing: the OpenAI component was gated by `ConfigurationPolicy.REQUIRE` on a secondary configuration that `TranslationServicesManagerImpl` deleted whenever no API key was set, so an unusable translator simply was not registered. The key now lives in the connector, which sends this module no notification when it changes — so the LLM component stays registered while the connector is unconfigured, and availability has to be checked at lookup time or it would shadow DeepL at ranking 10.

**DeepL no longer deactivates itself when an OpenAI key is present.** `DeepLTranslatorServiceImpl.activate` refused to become available if `translation.openai.api.key` was in its properties — an implicit "OpenAI wins" mutual exclusion. Ranking plus the availability check now expresses that precedence explicitly.

## Configuration

Provider, API key and default model are configured centrally in `org.jahia.modules.genai.cfg`. This module never sees a key.

| Legacy key | Status |
|---|---|
| `translation.openai.api.key` | **Ignored**, logs a warning. The obsolete `…assisted.openai` configuration is deleted on startup along with the key it held. |
| `translation.openai.model` | Read as a fallback for the new `translation.llm.model`, with a deprecation warning. |
| `translation.openai.prompt` | Read as a fallback for the new `translation.llm.prompt`, with a deprecation warning. |

`translation.llm.model` is an optional per-module override (empty = the connector's model), kept so translations can use a different model from other connector consumers. The service also gained a built-in default prompt: previously an absent `translation.openai.prompt` produced an NPE.

## Decisions taken

- **`genai-connector` is a hard `Jahia-Depends`.** The module will not start without it, DeepL-only installs included. The lighter alternative — leaving the reference unsatisfied when the connector is absent — was considered and rejected in favour of the deterministic wiring the issue asked for. Worth a conscious ack, since `genai-connector` is an `org.jahia.modules` licensed product module and this is `org.jahia.community`.
- The `Jahia-Depends` manifest header comes from the parent pom's `${jahia-depends}` mapping, so only the property is set — no bundle-plugin instruction is needed in this repo.
- `@NotNull` was reached through `openai-java`'s Kotlin transitives; the annotation went away with the SDK and was dropped rather than re-added as a dependency.

## Verification

- `mvn clean package` green, frontend build included.
- **Bundle shrinks from 36.6 MB to 2.4 MB** (-93%): `openai-java` was dragging in kotlin-stdlib, Jackson and okhttp. The bnd "classes in the wrong directory" warnings for those went with it.
- Deployed to a local Jahia 8.2.3 with `genai-connector` ACTIVE: the module reaches **ACTIVE**, so `Jahia-Depends` and the `org.jahia.modules.genai.api` import both resolve, and `LlmTranslatorService` activates — meaning its mandatory `GenAiService` reference wired.
- Generated DS descriptors confirm the intended shape: `LlmTranslatorService` bound to the main PID with no `configuration-policy`, DeepL still `require` on its own PID.

**Not verified: no live translation was run.** That needs a real provider call, which nothing in this repo's history has exercised either (see the EPIC's open gap). The multi-batch (>200 fields) and HTML-round-trip scenarios from the issue's test strategy are still to run against a configured provider.

## Out of scope

Multi-batch translations still run synchronously on the GraphQL thread; async/job execution stays a separate improvement, per the issue.
